### PR TITLE
<fix> input tensor device error in predict.py get_prediction

### DIFF
--- a/part2/02-streamlit/predict.py
+++ b/part2/02-streamlit/predict.py
@@ -19,6 +19,8 @@ def load_model() -> MyEfficientNet:
 
 def get_prediction(model:MyEfficientNet, image_bytes: bytes) -> Tuple[torch.Tensor, torch.Tensor]:
     tensor = transform_image(image_bytes=image_bytes)
+    device = torch.device("cuda" if torch.cuda.is_available else "cpu") 
+    tensor = tensor.to(device)
     outputs = model.forward(tensor)
     _, y_hat = outputs.max(1)
     return tensor, y_hat


### PR DESCRIPTION
OS:
Linux 1632a42ce5ba 4.4.0-59-generic #80-Ubuntu SMP Fri Jan 6 17:47:47 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux


GPU:
Sun Dec 12 12:41:29 2021       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 450.80.02    Driver Version: 450.80.02    CUDA Version: 11.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla V100-SXM2...  Off  | 00000000:00:05.0 Off |                  Off |
| N/A   32C    P0    49W / 300W |      0MiB / 32510MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+

현재 코드는 cpu 환경에서의 serving만을 염두해두었다고 가정을 하였습니다.  
하지만,
predict.py 에서 load_model() 모듈에서 model.to(device)로 현재 서버가 gpu인지 cpu인지 고려해주고 있습니다.

마찬가지로 prediction에서도 input을 model에 argument로 넘겨줄 때  , 현재 서버가 gpu인지 cpu인지 고려해주는 code가 필요한거 같습니다.





![image](https://user-images.githubusercontent.com/50165842/145698298-fd58e9fc-2460-4ff1-8c10-9083ed5c6a0e.png)


